### PR TITLE
scriptum マクロのブロック内改行で SakuraScript に \n を自動挿入

### DIFF
--- a/Signaculum/Notatio/Macro.lean
+++ b/Signaculum/Notatio/Macro.lean
@@ -235,19 +235,37 @@ private def scriptumParserCore (kw : String) : Lean.Parser.Parser :=
 @[term_elab scriptumMacro]
 def elabScriptum : TermElab := fun stx expectedType? => do
   let ss := stx[1].getArgs
-  -- 各シグナムノードを term に変換するにゃ
+  -- 各シグナムノードを term に變換するにゃ
   let genTerm (s : Lean.Syntax) : Lean.Elab.Term.TermElabM (TSyntax `term) := do
     if s.isIdent then
-      -- rawTextusFn 由来の裸 ident にゃ → 識別子名をテクストゥスとして直接 loqui にくるむにゃ
+      -- rawTextusFn 由來の裸 ident にゃ → 識別子名をテクストゥスとして直接 loqui にくるむにゃ
       `(Signaculum.Sakura.loqui $(Lean.Syntax.mkStrLit s.getId.toString))
     else
       let ts : TSyntax `sakuraSignum := ⟨s⟩
       `(expandSignum $ts)
   if h : 0 < ss.size then
+    -- フォンティスのタブラから行番號を得るにゃん♪
+    -- 異なる行のシグナム間に自動で linea（\n）を挿入するにゃ
+    let tabulaFontis ← getFileMap
+    let lineamSigni (s : Lean.Syntax) : Option Nat :=
+      let pos? := match s.getHeadInfo with
+        | .original (pos := p) .. => some p
+        | .synthetic (pos := p) .. => some p
+        | .none => none
+      pos?.map fun pos => (tabulaFontis.toPosition pos).line
     let mut body ← genTerm (ss[0]'h)
+    let mut lineaPrior := lineamSigni (ss[0]'h)
     for s in ss[1:] do
+      -- 前のシグナムと行が違ったら \n を挾むにゃ
+      let lineaCurrens := lineamSigni s
+      match lineaPrior, lineaCurrens with
+      | some lp, some lc =>
+        if lc > lp then
+          body ← `(Bind.bind $body fun () => Signaculum.Sakura.linea)
+      | _, _ => pure ()
       let next ← genTerm s
       body ← `(Bind.bind $body fun () => $next)
+      lineaPrior := lineaCurrens
     elabTerm body expectedType?
   else
     elabTerm (← `(pure ())) expectedType?

--- a/Signaculum/Notatio/Verificatio.lean
+++ b/Signaculum/Notatio/Verificatio.lean
@@ -87,4 +87,22 @@ example : Id.run (currere (scriptum! \f[valign, top]))
 example : Id.run (currere (scriptum! \f[valign, bottom]))
         = "\\f[valign,bottom]" := by native_decide
 
+-- ════════════════════════════════════════════════════
+--  行跨ぎ改行自動挿入の検證にゃん
+-- ════════════════════════════════════════════════════
+
+-- 條件1: 同一行不變性 — 單行なら \n は入らにゃいにゃん
+example : Id.run (currere (scriptum! \h \s[0] "hello" \e)) = "\\h\\s[0]hello\\e" := by native_decide
+
+-- 條件2: 行跨ぎ改行 — 異なる行の要素間に \n が插入されるにゃん
+example : Id.run (currere (scriptum!
+  \h \s[0]
+  "hello"
+  \e)) = "\\h\\s[0]\\nhello\\n\\e" := by native_decide
+
+-- 條件3: 先頭不挿入 — 最初の要素の前には \n が入らにゃいにゃん
+example : Id.run (currere (scriptum!
+  \h
+  \e)) = "\\h\\n\\e" := by native_decide
+
 end Signaculum.Notatio.Verificatio


### PR DESCRIPTION
elabScriptum エラボレーターで連続するシグナムの行番號を追跡し、
異なる行の要素間に自動で linea（\n）を挿入するやうにした。
同一行の要素間には挿入せず、單行 scriptum の動作は不變。

https://claude.ai/code/session_01WWCUZo8T5HLFSnRvy8zX7Q