### PR TITLE
Exhibibilis に Option α の非正格評價インスタンスを追加

### DIFF
--- a/Signaculum/Notatio/Macro.lean
+++ b/Signaculum/Notatio/Macro.lean
@@ -86,6 +86,23 @@ instance (priority := 95) {α : Type u} [Exhibibilis α IO] : Exhibibilis (List 
       let i : Fin n := ⟨idx % n, Nat.mod_lt idx (by omega)⟩
       Exhibibilis.exhibe (m := IO) a[i]
 
+-- Option α → some なら exhibe、none なら無出力にゃん（非正格評價）
+universe u in
+instance (priority := 92) {α : Type u} {m : Type → Type} [Monad m] [Exhibibilis α m] : Exhibibilis (Option α) m where
+  exhibe
+    | some a => Exhibibilis.exhibe (m := m) a
+    | none   => pure ()
+
+-- some のとき内側の exhibe に委譲するにゃん♪ 定義から自明にゃ
+universe u in
+theorem exhibeOptionSome_eq {α : Type u} {m : Type → Type} [Monad m] [Exhibibilis α m]
+    (a : α) : Exhibibilis.exhibe (m := m) (some a : Option α) = Exhibibilis.exhibe (m := m) a := rfl
+
+-- none のとき無出力にゃん♪ これも定義から自明にゃ
+universe u in
+theorem exhibeOptionNullus_eq {m : Type → Type} [Monad m] {α : Type} [Exhibibilis α m] :
+    Exhibibilis.exhibe (m := m) (none : Option α) = pure () := rfl
+
 -- Exhibibilis 經由の CoeDep にゃん。{expr} の型強制はぜんぶこゝを通るにゃ
 universe u in
 instance {α : Type u} {m : Type → Type} [Monad m] [Exhibibilis α m] (a : α) :

--- a/docs/SakuraScriptum.md
+++ b/docs/SakuraScriptum.md
@@ -736,6 +736,7 @@ def talkScriptum : SakuraPura Unit := scriptum!
 |---|---|---|
 | `String` | `loqui s` として表示 | 100 |
 | `Array α` / `List α` | ランダムに1要素選んで `exhibe` で表示（`SakuraIO` 文脈のみ） | 95 |
+| `Option α` | `some a` → `exhibe a`、`none` → 無出力（非正格評價） | 92 |
 | `m String` | モナドを実行して `loqui` で表示 | 90 |
 | `IO.Ref α` | 値を読み取って `toString` + `loqui`（`SakuraIO` 文脈のみ） | 85 |
 | `m α` (`ToString α`) | モナドを実行して `toString` + `loqui` | 80 |


### PR DESCRIPTION
some a は内側の exhibe に委譲し、none は無出力（pure ()）とする。
優先度 92 で汎用 ToString フォールバック（70）より先に解決される。
rfl 定理 exhibeOptionSome_eq / exhibeOptionNullus_eq で性質を証明。

https://claude.ai/code/session_01SSHbb981EXWyyaqmhQgjYp