### PR TITLE
ukadoc 仕様に基づく sakurascriptum マクロの三要件改善

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -10,6 +10,11 @@ pythonは使わないで下さい
 ・これをビルドするときは　lake build Signaculumでビルドして
 ・プラン作成後の実装中にプランから逸脱した変更（設計変更、追加、省略、回避策等）を独断で行った場合は、コミット前に必ずユーザーにその内容と理由を報告し確認を取ること
 
+## 参照ドキュメント
+
+- ukadoc sakurascript 一覧: https://ssp.shillest.net/ukadoc/manual/list_sakura_script.html
+- ukadoc トップ: https://ssp.shillest.net/ukadoc/manual/index.html
+
 ## sakurascriptum マクロの三原則
 
 sakurascriptum マクロ (`scriptum!`) は以下の三要件を常に満たすこと:


### PR DESCRIPTION
## Summary

- ukadoc 仕様 (https://ssp.shillest.net/ukadoc/manual/list_sakura_script.html) と比較して欠落していたランタイム関数約25個とマクロ構文約70個を追加（+896行）
- sakurascriptum マクロの三原則を CLAUDE.md に明文化
- 全追加分の `native_decide` 出力検証証明を Verificatio.lean に追加
- docs/SakuraScriptum.md のタグ一覧テーブルを更新

### 主な追加内容

**ランタイム関数 (Sakura/*.lean):**
- `\c[char,n]`, `\c[line,n]` 文字・行単位クリア
- `\__q` 範囲選択肢、`\q[title,script:...]` スクリプト実行型選択肢
- `\![moveasync,cancel]`, `\![lock,repaint,manual]` 等
- `\![call,ghost,...]`, `\![update,platform]`, `\![updateother,...]`
- `\![execute,extractarchive/compressarchive/createnar/emptyrecyclebin]`
- `\![execute,http-options,...]`, `\![execute,rss-post,...]`
- `\![anim,add,text,...]`, `\__v[options]` 音声合成
- `\![wait,syncobject,...]`, `%環境変数` 参照

**マクロ構文 (Notatio/*.lean):**
- `\0`, `\1` 旧形式スコープ
- `FenestraAperibilis` 全25列挙値の `\![open,...]`
- 他ゴースト/プラグイン系8構文
- 音響・動画・フィルター・HTTP全種・設定系全種
- `\_b[...]` バルーン画像4形式
- 可変長引数: `\q[title,event,r0,...]` と `\_s[ID,...]`
- `\f[anchor.font.color,...]`, `%month` 等の環境変数

## Test plan

- [x] `lake build Signaculum` ビルド成功
- [x] `Verificatio.lean` の全 `native_decide` 証明が通過（40+件）

https://claude.ai/code/session_01LpABnga6M2UuQNExSr4fPo