### PR TITLE
Add GitHub Actions workflow to build Signaculum library

### DIFF
--- a/.github/workflows/lean_lib_ci.yml
+++ b/.github/workflows/lean_lib_ci.yml
@@ -1,0 +1,15 @@
+name: Library Build CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-lib:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: leanprover/lean-action@v1
+        with:
+          build-args: "Signaculum"


### PR DESCRIPTION
The default `lake build` does not build the library target.
This workflow explicitly runs `lake build Signaculum` to ensure
the library is compiled and tested in CI.

https://claude.ai/code/session_01K6vKsntU3xTrhmCNczYXd3