### PR TITLE
第三原則違反を修正: ukadoc 仕様に基づく型安全性の強化

### DIFF
--- a/Signaculum/Notatio/Fenestra.lean
+++ b/Signaculum/Notatio/Fenestra.lean
@@ -2,6 +2,7 @@
 -- 窓制御・UI・モード・設定・開閉の構文規則にゃん♪
 
 import Signaculum.Notatio.Categoria
+import Signaculum.Notatio.Literalia
 import Signaculum.Sakura.Scriptum
 
 namespace Signaculum.Notatio
@@ -100,8 +101,8 @@ macro_rules | `(expandSignum \![set,windowstate, $s]) => `(Signaculum.Sakura.con
 syntax "\\!" "[set,alignmentondesktop," term "]" : sakuraSignum
 macro_rules | `(expandSignum \![set,alignmentondesktop, $d]) => `(Signaculum.Sakura.allineatioDesktop $d)
 
-syntax "\\!" "[set,balloonalign," term "]" : sakuraSignum
-macro_rules | `(expandSignum \![set,balloonalign, $n]) => `(Signaculum.Sakura.allineatioBullae $n)
+syntax "\\!" "[set,balloonalign," directioAllineatioBullaeLiteral "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, $d:directioAllineatioBullaeLiteral]) => `(Signaculum.Sakura.allineatioBullae (directioAllineatioBullaeL $d))
 
 syntax "\\!" "[set,balloontimeout," term "]" : sakuraSignum
 macro_rules | `(expandSignum \![set,balloontimeout, $n]) => `(Signaculum.Sakura.tempusBullae $n)
@@ -321,8 +322,8 @@ macro_rules | `(expandSignum \![set,trayballoon, $o]) => `(Signaculum.Sakura.con
 --  モード拡張 (Extensio Modorum)
 -- ════════════════════════════════════════════════════
 
-syntax "\\!" "[enter,selectmode," str "," str "]" : sakuraSignum
-macro_rules | `(expandSignum \![enter,selectmode, $m, $c]) => `(Signaculum.Sakura.ingredereModumSelectionis $m $c)
+syntax "\\!" "[enter,selectmode," "rect" "," str "]" : sakuraSignum
+macro_rules | `(expandSignum \![enter,selectmode, rect, $c]) => `(Signaculum.Sakura.ingredereModumSelectionis .rectus $c)
 
 syntax "\\!" "[leave,selectmode]" : sakuraSignum
 macro_rules | `(expandSignum \![leave,selectmode]) => `(Signaculum.Sakura.egrediereModumSelectionis)

--- a/Signaculum/Notatio/Fons.lean
+++ b/Signaculum/Notatio/Fons.lean
@@ -37,19 +37,21 @@ macro_rules | `(expandSignum \f[color, $c:colorisLiteral]) => `(Signaculum.Sakur
 syntax "shadowcolor" "," colorisLiteral : fontisClavis
 macro_rules | `(expandSignum \f[shadowcolor, $c:colorisLiteral]) => `(Signaculum.Sakura.colorUmbrae (colorisL $c))
 
--- 數値系にゃん
-syntax "height" "," term : fontisClavis
-macro_rules | `(expandSignum \f[height, $n]) => `(Signaculum.Sakura.altitudoLitterarum $n)
+-- 文字サイズ系にゃん（magnitudoLitterarumLiteral で px/+n/-n/n%/default が書けるにゃ）
+syntax "height" "," magnitudoLitterarumLiteral : fontisClavis
+macro_rules | `(expandSignum \f[height, $n:magnitudoLitterarumLiteral]) => `(Signaculum.Sakura.altitudoLitterarum (magnitudoLitterarumL $n))
 
 -- 文字列系にゃん
 syntax "name" "," term : fontisClavis
 macro_rules | `(expandSignum \f[name, $s]) => `(Signaculum.Sakura.nomenFontis $s)
 
-syntax "shadowstyle" "," term : fontisClavis
-macro_rules | `(expandSignum \f[shadowstyle, $s]) => `(Signaculum.Sakura.stylumUmbrae $s)
+-- 影スタイル系にゃん（stylusUmbraeLiteral で offset/outline/default が書けるにゃ）
+syntax "shadowstyle" "," stylusUmbraeLiteral : fontisClavis
+macro_rules | `(expandSignum \f[shadowstyle, $s:stylusUmbraeLiteral]) => `(Signaculum.Sakura.stylumUmbrae (stylusUmbraeL $s))
 
-syntax "outline" "," term : fontisClavis
-macro_rules | `(expandSignum \f[outline, $s]) => `(Signaculum.Sakura.contornus $s)
+-- 輪郭系にゃん（statusContorniLiteral で true/false/default/disable が書けるにゃ）
+syntax "outline" "," statusContorniLiteral : fontisClavis
+macro_rules | `(expandSignum \f[outline, $s:statusContorniLiteral]) => `(Signaculum.Sakura.contornus (statusContorniL $s))
 
 -- 方向系にゃん（リテラルで書けるにゃ）
 syntax "align" "," directioAllineatioLiteral : fontisClavis

--- a/Signaculum/Notatio/Literalia.lean
+++ b/Signaculum/Notatio/Literalia.lean
@@ -25,6 +25,14 @@ syntax num "," num "," num  : colorisLiteral
 syntax "#" ident             : colorisLiteral
 syntax str                   : colorisLiteral
 syntax "none"                : colorisLiteral
+syntax "default"             : colorisLiteral
+syntax "disable"             : colorisLiteral
+syntax (priority := high) "default" "." "anchor"          : colorisLiteral
+syntax (priority := high) "default" "." "anchornotselect" : colorisLiteral
+syntax (priority := high) "default" "." "anchorvisited"   : colorisLiteral
+syntax (priority := high) "default" "." "cursor"          : colorisLiteral
+syntax (priority := high) "default" "." "cursornotselect" : colorisLiteral
+syntax (priority := high) "default" "." "plain"           : colorisLiteral
 syntax ident                 : colorisLiteral
 syntax "(" term ")"          : colorisLiteral
 
@@ -41,6 +49,22 @@ macro_rules
       `(Signaculum.Sakura.Coloris.hex $s)
   | `(colorisL none) =>
       `(Signaculum.Sakura.Coloris.nullus)
+  | `(colorisL default . anchor) =>
+      `(Signaculum.Sakura.Coloris.praefinitusAncorae)
+  | `(colorisL default . anchornotselect) =>
+      `(Signaculum.Sakura.Coloris.praefinitusAncoraeNonElectae)
+  | `(colorisL default . anchorvisited) =>
+      `(Signaculum.Sakura.Coloris.praefinitusAncoraeVisae)
+  | `(colorisL default . cursor) =>
+      `(Signaculum.Sakura.Coloris.praefinitusCursoris)
+  | `(colorisL default . cursornotselect) =>
+      `(Signaculum.Sakura.Coloris.praefinitusCursorisNonElecti)
+  | `(colorisL default . plain) =>
+      `(Signaculum.Sakura.Coloris.praefinitusPlanus)
+  | `(colorisL default) =>
+      `(Signaculum.Sakura.Coloris.praefinitus)
+  | `(colorisL disable) =>
+      `(Signaculum.Sakura.Coloris.inhabilis)
   | `(colorisL $n:ident) => do
       let s : String := n.getId.toString
       `(Signaculum.Sakura.Coloris.nomen $(Lean.Syntax.mkStrLit s))
@@ -122,9 +146,28 @@ macro_rules
 --  methodusMarciLiteral (MethodusMarci 型リテラル)
 -- ════════════════════════════════════════════════════
 
-/-- マーカー描畫方法リテラルカテゴリアにゃん。xor/alpha/normal/default で書けるにゃ -/
+/-- マーカー描畫方法リテラルカテゴリアにゃん。
+    Win32 SetROP2 の全モード + SSP 擴張 (xor/alpha/normal/default) で書けるにゃ -/
 declare_syntax_cat methodusMarciLiteral
 
+-- Win32 SetROP2 モードにゃん
+syntax "black"       : methodusMarciLiteral
+syntax "notmergepen" : methodusMarciLiteral
+syntax "masknotpen"  : methodusMarciLiteral
+syntax "notcopypen"  : methodusMarciLiteral
+syntax "maskpennot"  : methodusMarciLiteral
+syntax "not"         : methodusMarciLiteral
+syntax "xorpen"      : methodusMarciLiteral
+syntax "notmaskpen"  : methodusMarciLiteral
+syntax "maskpen"     : methodusMarciLiteral
+syntax "notxorpen"   : methodusMarciLiteral
+syntax "nop"         : methodusMarciLiteral
+syntax "mergenotpen" : methodusMarciLiteral
+syntax "copypen"     : methodusMarciLiteral
+syntax "mergepennot" : methodusMarciLiteral
+syntax "mergepen"    : methodusMarciLiteral
+syntax "white"       : methodusMarciLiteral
+-- SSP 擴張にゃん
 syntax "xor"     : methodusMarciLiteral
 syntax "alpha"   : methodusMarciLiteral
 syntax "normal"  : methodusMarciLiteral
@@ -134,10 +177,150 @@ syntax "(" term ")" : methodusMarciLiteral
 syntax "methodusMarciL " methodusMarciLiteral : term
 
 macro_rules
-  | `(methodusMarciL xor)     => `(Signaculum.Sakura.MethodusMarci.xor)
-  | `(methodusMarciL alpha)   => `(Signaculum.Sakura.MethodusMarci.alpha)
-  | `(methodusMarciL normal)  => `(Signaculum.Sakura.MethodusMarci.normal)
-  | `(methodusMarciL default) => `(Signaculum.Sakura.MethodusMarci.praefinitus)
-  | `(methodusMarciL ($e))    => `($e)
+  | `(methodusMarciL black)       => `(Signaculum.Sakura.MethodusMarci.black)
+  | `(methodusMarciL notmergepen) => `(Signaculum.Sakura.MethodusMarci.notmergepen)
+  | `(methodusMarciL masknotpen)  => `(Signaculum.Sakura.MethodusMarci.masknotpen)
+  | `(methodusMarciL notcopypen)  => `(Signaculum.Sakura.MethodusMarci.notcopypen)
+  | `(methodusMarciL maskpennot)  => `(Signaculum.Sakura.MethodusMarci.maskpennot)
+  | `(methodusMarciL not)         => `(Signaculum.Sakura.MethodusMarci.not)
+  | `(methodusMarciL xorpen)      => `(Signaculum.Sakura.MethodusMarci.xorpen)
+  | `(methodusMarciL notmaskpen)  => `(Signaculum.Sakura.MethodusMarci.notmaskpen)
+  | `(methodusMarciL maskpen)     => `(Signaculum.Sakura.MethodusMarci.maskpen)
+  | `(methodusMarciL notxorpen)   => `(Signaculum.Sakura.MethodusMarci.notxorpen)
+  | `(methodusMarciL nop)         => `(Signaculum.Sakura.MethodusMarci.nop)
+  | `(methodusMarciL mergenotpen) => `(Signaculum.Sakura.MethodusMarci.mergenotpen)
+  | `(methodusMarciL copypen)     => `(Signaculum.Sakura.MethodusMarci.copypen)
+  | `(methodusMarciL mergepennot) => `(Signaculum.Sakura.MethodusMarci.mergepennot)
+  | `(methodusMarciL mergepen)    => `(Signaculum.Sakura.MethodusMarci.mergepen)
+  | `(methodusMarciL white)       => `(Signaculum.Sakura.MethodusMarci.white)
+  | `(methodusMarciL xor)         => `(Signaculum.Sakura.MethodusMarci.xor)
+  | `(methodusMarciL alpha)       => `(Signaculum.Sakura.MethodusMarci.alpha)
+  | `(methodusMarciL normal)      => `(Signaculum.Sakura.MethodusMarci.normal)
+  | `(methodusMarciL default)     => `(Signaculum.Sakura.MethodusMarci.praefinitus)
+  | `(methodusMarciL ($e))        => `($e)
+
+
+-- ════════════════════════════════════════════════════
+--  stylusUmbraeLiteral (StylusUmbrae 型リテラル)
+-- ════════════════════════════════════════════════════
+
+/-- 文字影スタイルリテラルカテゴリアにゃん。offset/outline/default で書けるにゃ -/
+declare_syntax_cat stylusUmbraeLiteral
+
+syntax "offset"  : stylusUmbraeLiteral
+syntax "outline" : stylusUmbraeLiteral
+syntax "default" : stylusUmbraeLiteral
+syntax "(" term ")" : stylusUmbraeLiteral
+
+syntax "stylusUmbraeL " stylusUmbraeLiteral : term
+
+macro_rules
+  | `(stylusUmbraeL offset)  => `(Signaculum.Sakura.StylusUmbrae.offset)
+  | `(stylusUmbraeL outline) => `(Signaculum.Sakura.StylusUmbrae.contornus)
+  | `(stylusUmbraeL default) => `(Signaculum.Sakura.StylusUmbrae.praefinitus)
+  | `(stylusUmbraeL ($e))    => `($e)
+
+
+-- ════════════════════════════════════════════════════
+--  statusContorniLiteral (StatusContorni 型リテラル)
+-- ════════════════════════════════════════════════════
+
+/-- 文字輪郭リテラルカテゴリアにゃん。true/false/default/disable で書けるにゃ -/
+declare_syntax_cat statusContorniLiteral
+
+syntax "true"    : statusContorniLiteral
+syntax "false"   : statusContorniLiteral
+syntax "default" : statusContorniLiteral
+syntax "disable" : statusContorniLiteral
+syntax "(" term ")" : statusContorniLiteral
+
+syntax "statusContorniL " statusContorniLiteral : term
+
+macro_rules
+  | `(statusContorniL true)    => `(Signaculum.Sakura.StatusContorni.activus)
+  | `(statusContorniL false)   => `(Signaculum.Sakura.StatusContorni.inactivus)
+  | `(statusContorniL default) => `(Signaculum.Sakura.StatusContorni.praefinitus)
+  | `(statusContorniL disable) => `(Signaculum.Sakura.StatusContorni.inhabilis)
+  | `(statusContorniL ($e))    => `($e)
+
+
+-- ════════════════════════════════════════════════════
+--  directioAllineatioBullaeLiteral (DirectioAllineatioBullae 型リテラル)
+-- ════════════════════════════════════════════════════
+
+/-- 吹出し方向リテラルカテゴリアにゃん。left/center/top/right/bottom/none で書けるにゃ -/
+declare_syntax_cat directioAllineatioBullaeLiteral
+
+syntax "left"   : directioAllineatioBullaeLiteral
+syntax "center" : directioAllineatioBullaeLiteral
+syntax "top"    : directioAllineatioBullaeLiteral
+syntax "right"  : directioAllineatioBullaeLiteral
+syntax "bottom" : directioAllineatioBullaeLiteral
+syntax "none"   : directioAllineatioBullaeLiteral
+syntax "(" term ")" : directioAllineatioBullaeLiteral
+
+syntax "directioAllineatioBullaeL " directioAllineatioBullaeLiteral : term
+
+macro_rules
+  | `(directioAllineatioBullaeL left)   => `(Signaculum.Sakura.DirectioAllineatioBullae.sinistrum)
+  | `(directioAllineatioBullaeL center) => `(Signaculum.Sakura.DirectioAllineatioBullae.centrum)
+  | `(directioAllineatioBullaeL top)    => `(Signaculum.Sakura.DirectioAllineatioBullae.summum)
+  | `(directioAllineatioBullaeL right)  => `(Signaculum.Sakura.DirectioAllineatioBullae.dextrum)
+  | `(directioAllineatioBullaeL bottom) => `(Signaculum.Sakura.DirectioAllineatioBullae.imum)
+  | `(directioAllineatioBullaeL none)   => `(Signaculum.Sakura.DirectioAllineatioBullae.nullus)
+  | `(directioAllineatioBullaeL ($e))   => `($e)
+
+
+-- ════════════════════════════════════════════════════
+--  modusTapetisLiteral (ModusTapetis 型リテラル)
+-- ════════════════════════════════════════════════════
+
+/-- 壁紙モードリテラルカテゴリアにゃん。center/tile/stretch/stretch-x/stretch-y/span で書けるにゃ -/
+declare_syntax_cat modusTapetisLiteral
+
+syntax "center"  : modusTapetisLiteral
+syntax "tile"    : modusTapetisLiteral
+syntax "stretch" : modusTapetisLiteral
+syntax (priority := high) "stretch" "-" "x" : modusTapetisLiteral
+syntax (priority := high) "stretch" "-" "y" : modusTapetisLiteral
+syntax "span"    : modusTapetisLiteral
+syntax "(" term ")" : modusTapetisLiteral
+
+syntax "modusTapetisL " modusTapetisLiteral : term
+
+macro_rules
+  | `(modusTapetisL center)      => `(Signaculum.Sakura.ModusTapetis.centrum)
+  | `(modusTapetisL tile)        => `(Signaculum.Sakura.ModusTapetis.tessella)
+  | `(modusTapetisL stretch - x) => `(Signaculum.Sakura.ModusTapetis.extendeX)
+  | `(modusTapetisL stretch - y) => `(Signaculum.Sakura.ModusTapetis.extendeY)
+  | `(modusTapetisL stretch)     => `(Signaculum.Sakura.ModusTapetis.extende)
+  | `(modusTapetisL span)        => `(Signaculum.Sakura.ModusTapetis.spatium)
+  | `(modusTapetisL ($e))        => `($e)
+
+
+-- ════════════════════════════════════════════════════
+--  magnitudoLitterarumLiteral (MagnitudoLitterarum 型リテラル)
+-- ════════════════════════════════════════════════════
+
+/-- 文字の大きさリテラルカテゴリアにゃん。
+    數值=絕對px、+n/-n=相對、n%=百分率、default=既定にゃ -/
+declare_syntax_cat magnitudoLitterarumLiteral
+
+syntax "default" : magnitudoLitterarumLiteral
+syntax "+" num   : magnitudoLitterarumLiteral
+syntax "-" num   : magnitudoLitterarumLiteral
+syntax num "%"   : magnitudoLitterarumLiteral
+syntax num       : magnitudoLitterarumLiteral
+syntax "(" term ")" : magnitudoLitterarumLiteral
+
+syntax "magnitudoLitterarumL " magnitudoLitterarumLiteral : term
+
+macro_rules
+  | `(magnitudoLitterarumL default) => `(Signaculum.Sakura.MagnitudoLitterarum.praefinita)
+  | `(magnitudoLitterarumL + $n:num) => `(Signaculum.Sakura.MagnitudoLitterarum.relativa $n)
+  | `(magnitudoLitterarumL - $n:num) => `(Signaculum.Sakura.MagnitudoLitterarum.relativa (- $n))
+  | `(magnitudoLitterarumL $n:num %) => `(Signaculum.Sakura.MagnitudoLitterarum.proportio $n)
+  | `(magnitudoLitterarumL $n:num)   => `(Signaculum.Sakura.MagnitudoLitterarum.absoluta $n)
+  | `(magnitudoLitterarumL ($e))     => `($e)
 
 end Signaculum.Notatio

--- a/Signaculum/Notatio/Systema.lean
+++ b/Signaculum/Notatio/Systema.lean
@@ -2,6 +2,7 @@
 -- イヴェントゥム・音響・動畫・呼出・實行・變更の構文規則にゃん♪
 
 import Signaculum.Notatio.Categoria
+import Signaculum.Notatio.Literalia
 import Signaculum.Sakura.Scriptum
 
 namespace Signaculum.Notatio
@@ -186,8 +187,16 @@ syntax "\\!" "[load,makoto]" : sakuraSignum
 macro_rules | `(expandSignum \![load,makoto]) => `(Signaculum.Sakura.oneraMakoto)
 
 -- 着替・效果にゃん
-syntax "\\!" "[bind," str "," str "," str "]" : sakuraSignum
-macro_rules | `(expandSignum \![bind, $c, $p, $v]) => `(Signaculum.Sakura.nexaDressup $c $p $v)
+syntax "\\!" "[bind," str "," str "," num "]" : sakuraSignum
+macro_rules
+  | `(expandSignum \![bind, $c, $p, $v:num]) => do
+    let n := v.getNat
+    if n == 1 then `(Signaculum.Sakura.nexaDressup $c $p (some true))
+    else if n == 0 then `(Signaculum.Sakura.nexaDressup $c $p (some false))
+    else Lean.Macro.throwError "\\![bind,...] の値は 0 か 1 のみにゃ"
+
+syntax "\\!" "[bind," str "," str "]" : sakuraSignum
+macro_rules | `(expandSignum \![bind, $c, $p]) => `(Signaculum.Sakura.nexaDressup $c $p none)
 
 syntax "\\!" "[effect," str "," term "," str "]" : sakuraSignum
 macro_rules | `(expandSignum \![effect, $p, $s, $r]) => `(Signaculum.Sakura.applicaEffectum $p $s $r)
@@ -393,7 +402,10 @@ syntax "\\!" "[set,othersurfacechange," term "]" : sakuraSignum
 macro_rules | `(expandSignum \![set,othersurfacechange, $b]) => `(Signaculum.Sakura.configuraAliasSuperficies $b)
 
 syntax "\\!" "[set,wallpaper," str "]" : sakuraSignum
-macro_rules | `(expandSignum \![set,wallpaper, $v]) => `(Signaculum.Sakura.configuraTapete $v)
+macro_rules | `(expandSignum \![set,wallpaper, $v]) => `(Signaculum.Sakura.configuraTapete $v none)
+
+syntax "\\!" "[set,wallpaper," str "," modusTapetisLiteral "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, $m:modusTapetisLiteral]) => `(Signaculum.Sakura.configuraTapete $v (some (modusTapetisL $m)))
 
 syntax "\\!" "[set,shioridebugmode]" : sakuraSignum
 macro_rules | `(expandSignum \![set,shioridebugmode]) => `(Signaculum.Sakura.configuraShioriDebug)

--- a/Signaculum/Notatio/Verificatio.lean
+++ b/Signaculum/Notatio/Verificatio.lean
@@ -218,4 +218,89 @@ example : Id.run (currereScriptum (scriptum! \__v["speed=100"])) = "\\__v[speed=
 
 example : Id.run (currereScriptum (scriptum! \f[anchor.font.color, red])) = "\\f[anchor.font.color,red]" := by native_decide
 
+-- ════════════════════════════════════════════════════
+--  colorisLiteral 擴張の検證にゃん（default/disable 系）
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \f[color, default]))
+        = "\\f[color,default]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[color, disable]))
+        = "\\f[color,disable]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[color, default.anchor]))
+        = "\\f[color,default.anchor]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[color, default.cursor]))
+        = "\\f[color,default.cursor]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[color, default.plain]))
+        = "\\f[color,default.plain]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  stylusUmbraeLiteral の検證にゃん
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \f[shadowstyle, offset]))
+        = "\\f[shadowstyle,offset]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[shadowstyle, outline]))
+        = "\\f[shadowstyle,outline]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[shadowstyle, default]))
+        = "\\f[shadowstyle,default]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  statusContorniLiteral の検證にゃん
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \f[outline, true]))
+        = "\\f[outline,true]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[outline, false]))
+        = "\\f[outline,false]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[outline, disable]))
+        = "\\f[outline,disable]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  magnitudoLitterarumLiteral の検證にゃん
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \f[height, 15]))
+        = "\\f[height,15]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[height, default]))
+        = "\\f[height,default]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  directioAllineatioBullaeLiteral の検證にゃん
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, left]))
+        = "\\![set,balloonalign,left]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, center]))
+        = "\\![set,balloonalign,center]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, none]))
+        = "\\![set,balloonalign,none]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  selectmode の検證にゃん
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \![enter,selectmode, rect, "0,0,100,100"]))
+        = "\\![enter,selectmode,rect,0\\,0\\,100\\,100]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  methodusMarciLiteral 擴張の検證にゃん（ROP2 モード）
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \f[cursormethod, copypen]))
+        = "\\f[cursormethod,copypen]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[cursormethod, notmaskpen]))
+        = "\\f[cursormethod,notmaskpen]" := by native_decide
+
 end Signaculum.Notatio.Verificatio

--- a/Signaculum/Sakura/Fenestra.lean
+++ b/Signaculum/Sakura/Fenestra.lean
@@ -150,9 +150,10 @@ def lineaProportionalis {m : Type → Type} [Monad m] (n : Int) : SakuraM m Unit
 def linearisAbrogatur {m : Type → Type} [Monad m] : SakuraM m Unit :=
   emitte "\\_n"
 
-/-- 吹出しの方向IDを設定するにゃん（\\![set,balloonalign,id]）-/
-def allineatioBullae {m : Type → Type} [Monad m] (id : Nat) : SakuraM m Unit :=
-  emitte s!"\\![set,balloonalign,{id}]"
+/-- 吹出しの方向を設定するにゃん（\\![set,balloonalign,方向]）。
+    `sinistrum`=左、`centrum`=中央、`summum`=上、`dextrum`=右、`imum`=下、`nullus`=自動にゃ -/
+def allineatioBullae {m : Type → Type} [Monad m] (directio : DirectioAllineatioBullae) : SakuraM m Unit :=
+  emitte s!"\\![set,balloonalign,{directio.toString}]"
 
 /-- 吹出しを一定時間後に消すにゃん（\\![set,balloontimeout,ms]）-/
 def tempusBullae {m : Type → Type} [Monad m] (ms : Nat) : SakuraM m Unit :=
@@ -290,8 +291,8 @@ def allineatioDesktop {m : Type → Type} [Monad m] (directio : DirectioDesktop)
   emitte s!"\\![set,alignmentondesktop,{directio.toString}]"
 
 /-- 表面の拡大率を設定するにゃん（\\![set,scaling,比率]）。
-    比率はパーセント整數にゃ。SSP 固有にゃん -/
-def configuratioScalae {m : Type → Type} [Monad m] (proportio : Nat) : SakuraM m Unit :=
+    比率はパーセント整數にゃ。負値で軸反轉にゃ。SSP 固有にゃん -/
+def configuratioScalae {m : Type → Type} [Monad m] (proportio : Int) : SakuraM m Unit :=
   emitte s!"\\![set,scaling,{proportio}]"
 
 /-- 透明度を設定するにゃん（\\![set,alpha,值]）。0=完全透明、100=不透明にゃ -/
@@ -386,10 +387,11 @@ def ingredereModumCollisionis {m : Type → Type} [Monad m]
 def egrediereModumCollisionis {m : Type → Type} [Monad m] : SakuraM m Unit :=
   emitte "\\![leave,collisionmode]"
 
-/-- 選擇モードに入るにゃん（\\![enter,selectmode,mode,coords|name]）-/
+/-- 選擇モードに入るにゃん（\\![enter,selectmode,mode,coords|name]）。
+    modus に `ModusSelectionis` を指定するにゃ。coordsVelNomen は座標文字列かコリジョン名にゃ -/
 def ingredereModumSelectionis {m : Type → Type} [Monad m]
-    (modus coordsVelNomen : String) : SakuraM m Unit :=
-  emitte s!"\\![enter,selectmode,{evadeArgumentum modus},{evadeArgumentum coordsVelNomen}]"
+    (modus : ModusSelectionis) (coordsVelNomen : String) : SakuraM m Unit :=
+  emitte s!"\\![enter,selectmode,{modus.toString},{evadeArgumentum coordsVelNomen}]"
 
 /-- 選擇モードから出るにゃん（\\![leave,selectmode]）-/
 def egrediereModumSelectionis {m : Type → Type} [Monad m] : SakuraM m Unit :=
@@ -437,13 +439,13 @@ def seraRepicturaBullaeManualiter {m : Type → Type} [Monad m] : SakuraM m Unit
 --  スケーリング・透明度拡張 (Extensio Scalae et Alphae)
 -- ════════════════════════════════════════════════════
 
-/-- 縱横別々にスケーリングするにゃん（\\![set,scaling,x,y]）-/
-def configuraScalamDualem {m : Type → Type} [Monad m] (x y : Nat) : SakuraM m Unit :=
+/-- 縱横別々にスケーリングするにゃん（\\![set,scaling,x,y]）。負値で軸反轉にゃ -/
+def configuraScalamDualem {m : Type → Type} [Monad m] (x y : Int) : SakuraM m Unit :=
   emitte s!"\\![set,scaling,{x},{y}]"
 
-/-- アニメーション付きスケーリングにゃん（\\![set,scaling,x,y,options]）-/
+/-- アニメーション付きスケーリングにゃん（\\![set,scaling,x,y,options]）。負値で軸反轉にゃ -/
 def configuraScalamAnimatam {m : Type → Type} [Monad m]
-    (x y : Nat) (optiones : String) : SakuraM m Unit :=
+    (x y : Int) (optiones : String) : SakuraM m Unit :=
   emitte s!"\\![set,scaling,{x},{y},{evadeArgumentum optiones}]"
 
 /-- オプション付き透明度設定にゃん（\\![set,alpha,value,options]）-/

--- a/Signaculum/Sakura/Systema.lean
+++ b/Signaculum/Sakura/Systema.lean
@@ -69,10 +69,14 @@ def animaPurgat {m : Type → Type} [Monad m] (scopus animId : Nat) : SakuraM m 
 def animaTranslatio {m : Type → Type} [Monad m] (scopus animId : Nat) (x y : Int) : SakuraM m Unit :=
   emitte s!"\\![anim,offset,{scopus},{animId},{x},{y}]"
 
-/-- 着せ替えパーツを切り替へるにゃん（\\![bind,category,part,value]）-/
+/-- 着せ替えパーツを切り替へるにゃん（\\![bind,category,part,value]）。
+    valor: `some true`=着衣(1)、`some false`=脱衣(0)、`none`=トグル（省略）にゃ -/
 def nexaDressup {m : Type → Type} [Monad m]
-    (categoria pars valor : String) : SakuraM m Unit :=
-  emitte s!"\\![bind,{evadeArgumentum categoria},{evadeArgumentum pars},{evadeArgumentum valor}]"
+    (categoria pars : String) (valor : Option Bool := none) : SakuraM m Unit :=
+  match valor with
+  | some true  => emitte s!"\\![bind,{evadeArgumentum categoria},{evadeArgumentum pars},1]"
+  | some false => emitte s!"\\![bind,{evadeArgumentum categoria},{evadeArgumentum pars},0]"
+  | none       => emitte s!"\\![bind,{evadeArgumentum categoria},{evadeArgumentum pars}]"
 
 /-- 效果プラグインを適用するにゃん（\\![effect,plugin,speed,parameter]）-/
 def applicaEffectum {m : Type → Type} [Monad m]
@@ -387,11 +391,13 @@ def configuraAliosGhostes {m : Type → Type} [Monad m] (modus : ModusGhostAlien
 def configuraAliasSuperficies {m : Type → Type} [Monad m] (b : Bool) : SakuraM m Unit :=
   emitte s!"\\![set,othersurfacechange,{if b then "true" else "false"}]"
 
-/-- 壁紙を設定するにゃん（\\![set,wallpaper,file,option]）-/
+/-- 壁紙を設定するにゃん（\\![set,wallpaper,file,option]）。
+    optio: `center`/`tile`/`stretch`/`stretch-x`/`stretch-y`/`span` にゃ -/
 def configuraTapete {m : Type → Type} [Monad m]
-    (via : String) (optio : String := "") : SakuraM m Unit :=
-  if optio.isEmpty then emitte s!"\\![set,wallpaper,{evadeArgumentum via}]"
-  else emitte s!"\\![set,wallpaper,{evadeArgumentum via},{evadeArgumentum optio}]"
+    (via : String) (optio : Option ModusTapetis := none) : SakuraM m Unit :=
+  match optio with
+  | none   => emitte s!"\\![set,wallpaper,{evadeArgumentum via}]"
+  | some m => emitte s!"\\![set,wallpaper,{evadeArgumentum via},{m.toString}]"
 
 -- ════════════════════════════════════════════════════
 --  音響拡張2 (Extensio Soni II)

--- a/Signaculum/Sakura/Textus.lean
+++ b/Signaculum/Sakura/Textus.lean
@@ -158,9 +158,10 @@ def deletura {m : Type → Type} [Monad m] (b : Bool := true) : SakuraM m Unit :
 def color {m : Type → Type} [Monad m] (c : Coloris) : SakuraM m Unit :=
   emitte s!"\\f[color,{c.toString}]"
 
-/-- 文字の大きさ（\\f[height,n]）にゃん -/
-def altitudoLitterarum {m : Type → Type} [Monad m] (n : Nat) : SakuraM m Unit :=
-  emitte s!"\\f[height,{n}]"
+/-- 文字の大きさ（\\f[height,...]）にゃん。
+    絕對ピクセル、相對（+/-）、百分率、default が指定できるにゃ -/
+def altitudoLitterarum {m : Type → Type} [Monad m] (mag : MagnitudoLitterarum) : SakuraM m Unit :=
+  emitte s!"\\f[height,{mag.toString}]"
 
 /-- 書體名の設定（\\f[name,font]）にゃん -/
 def nomenFontis {m : Type → Type} [Monad m] (nomen : String) : SakuraM m Unit :=
@@ -179,13 +180,15 @@ def allineatioVerticalis {m : Type → Type} [Monad m] (directio : DirectioVerti
 def colorUmbrae {m : Type → Type} [Monad m] (coloris : Coloris) : SakuraM m Unit :=
   emitte s!"\\f[shadowcolor,{coloris.toString}]"
 
-/-- 文字影のスタイルを設定するにゃん（\\f[shadowstyle,スタイル]）-/
-def stylumUmbrae {m : Type → Type} [Monad m] (stylus : String) : SakuraM m Unit :=
-  emitte s!"\\f[shadowstyle,{evadeArgumentum stylus}]"
+/-- 文字影のスタイルを設定するにゃん（\\f[shadowstyle,スタイル]）。
+    `offset`=右下ずらし、`contornus`=輪郭風、`praefinitus`=既定にゃ -/
+def stylumUmbrae {m : Type → Type} [Monad m] (stylus : StylusUmbrae) : SakuraM m Unit :=
+  emitte s!"\\f[shadowstyle,{stylus.toString}]"
 
-/-- 文字の輪郭を設定するにゃん（\\f[outline,パラメータ]）-/
-def contornus {m : Type → Type} [Monad m] (parametrum : String) : SakuraM m Unit :=
-  emitte s!"\\f[outline,{evadeArgumentum parametrum}]"
+/-- 文字の輪郭を設定するにゃん（\\f[outline,パラメータ]）。
+    `activus`=有效、`inactivus`=無效、`praefinitus`=既定、`inhabilis`=無效化にゃ -/
+def contornus {m : Type → Type} [Monad m] (parametrum : StatusContorni) : SakuraM m Unit :=
+  emitte s!"\\f[outline,{parametrum.toString}]"
 
 /-- 下付き文字の切替にゃん（\\f[sub,true/false]）-/
 def subscriptus {m : Type → Type} [Monad m] (b : Bool := true) : SakuraM m Unit :=

--- a/Signaculum/Sakura/Typi.lean
+++ b/Signaculum/Sakura/Typi.lean
@@ -77,12 +77,31 @@ inductive FormaMarci where
   deriving Repr
 
 /-- 選擇肢マーカーの描畫方法にゃん。
-    `xor`=XOR 描畫、`alpha`=α合成、`normal`=通常、`praefinitus`=既定にゃ -/
+    Win32 SetROP2 の全オペレーターに加へ、SSP 擴張の `alpha`/`normal` も使へるにゃ。
+    `R2_` プレフィクスなしの小文字で指定するにゃん -/
 inductive MethodusMarci where
-  | xor
-  | alpha
-  | normal
-  | praefinitus
+  -- Win32 SetROP2 オペレーターにゃん
+  | black          -- R2_BLACK
+  | notmergepen    -- R2_NOTMERGEPEN
+  | masknotpen     -- R2_MASKNOTPEN
+  | notcopypen     -- R2_NOTCOPYPEN
+  | maskpennot     -- R2_MASKPENNOT
+  | not            -- R2_NOT
+  | xorpen         -- R2_XORPEN
+  | notmaskpen     -- R2_NOTMASKPEN
+  | maskpen        -- R2_MASKPEN
+  | notxorpen      -- R2_NOTXORPEN
+  | nop            -- R2_NOP
+  | mergenotpen    -- R2_MERGENOTPEN
+  | copypen        -- R2_COPYPEN
+  | mergepennot    -- R2_MERGEPENNOT
+  | mergepen       -- R2_MERGEPEN
+  | white          -- R2_WHITE
+  -- SSP 擴張にゃん
+  | xor            -- xor（R2_XORPEN の別名にゃ）
+  | alpha          -- α合成
+  | normal         -- 通常描畫
+  | praefinitus    -- default（既定に戾すにゃ）
   deriving Repr
 
 /-- 文字揃への方向にゃん。
@@ -126,9 +145,25 @@ def FormaMarci.toString : FormaMarci → String
   | .praefinitus   => "default"
 
 def MethodusMarci.toString : MethodusMarci → String
-  | .xor        => "xor"
-  | .alpha      => "alpha"
-  | .normal     => "normal"
+  | .black       => "black"
+  | .notmergepen => "notmergepen"
+  | .masknotpen  => "masknotpen"
+  | .notcopypen  => "notcopypen"
+  | .maskpennot  => "maskpennot"
+  | .not         => "not"
+  | .xorpen      => "xorpen"
+  | .notmaskpen  => "notmaskpen"
+  | .maskpen     => "maskpen"
+  | .notxorpen   => "notxorpen"
+  | .nop         => "nop"
+  | .mergenotpen => "mergenotpen"
+  | .copypen     => "copypen"
+  | .mergepennot => "mergepennot"
+  | .mergepen    => "mergepen"
+  | .white       => "white"
+  | .xor         => "xor"
+  | .alpha       => "alpha"
+  | .normal      => "normal"
   | .praefinitus => "default"
 
 def DirectioAllineatio.toString : DirectioAllineatio → String
@@ -152,23 +187,144 @@ def DirectioDesktop.toString : DirectioDesktop → String
   | .imum   => "bottom"
   | .liber  => "free"
 
+/-- 吹出し方向の設定にゃん。`allineatioBullae` に渡すにゃ。
+    ukadoc の `\\![set,balloonalign,...]` に對應するにゃん。
+    `sinistrum`=左、`centrum`=中央、`summum`=上、`dextrum`=右、`imum`=下、`nullus`=自動にゃ -/
+inductive DirectioAllineatioBullae where
+  | sinistrum   -- left
+  | centrum     -- center
+  | summum      -- top
+  | dextrum     -- right
+  | imum        -- bottom
+  | nullus      -- none（自動切替にゃ）
+  deriving Repr
+
+def DirectioAllineatioBullae.toString : DirectioAllineatioBullae → String
+  | .sinistrum => "left"
+  | .centrum   => "center"
+  | .summum    => "top"
+  | .dextrum   => "right"
+  | .imum      => "bottom"
+  | .nullus    => "none"
+
+/-- 文字影のスタイルにゃん。`stylumUmbrae` に渡すにゃ。
+    ukadoc の `\\f[shadowstyle,...]` に對應するにゃん。
+    `offset`=右下ずらし、`contornus`=輪郭風、`praefinitus`=既定にゃ -/
+inductive StylusUmbrae where
+  | offset      -- offset（右下ずらし影にゃ）
+  | contornus   -- outline（輪郭風影にゃ）
+  | praefinitus -- default（既定に戾すにゃ）
+  deriving Repr
+
+def StylusUmbrae.toString : StylusUmbrae → String
+  | .offset      => "offset"
+  | .contornus   => "outline"
+  | .praefinitus => "default"
+
+/-- 文字輪郭の狀態にゃん。`contornus` に渡すにゃ。
+    ukadoc の `\\f[outline,...]` に對應するにゃん。
+    `activus`=有效、`inactivus`=無效、`praefinitus`=既定、`inhabilis`=無效化にゃ -/
+inductive StatusContorni where
+  | activus     -- true / 1
+  | inactivus   -- false / 0
+  | praefinitus -- default
+  | inhabilis   -- disable
+  deriving Repr
+
+def StatusContorni.toString : StatusContorni → String
+  | .activus     => "true"
+  | .inactivus   => "false"
+  | .praefinitus => "default"
+  | .inhabilis   => "disable"
+
+/-- 壁紙の表示モードにゃん。`configuraTapete` に渡すにゃ。
+    ukadoc の `\\![set,wallpaper,...,option]` に對應するにゃん -/
+inductive ModusTapetis where
+  | centrum   -- center（中央配置にゃ）
+  | tessella  -- tile（タイル配置にゃ）
+  | extende   -- stretch（引き伸ばしにゃ）
+  | extendeX  -- stretch-x（橫方向のみ引き伸ばしにゃ）
+  | extendeY  -- stretch-y（縱方向のみ引き伸ばしにゃ）
+  | spatium   -- span（複數モニタにまたがるにゃ）
+  deriving Repr
+
+def ModusTapetis.toString : ModusTapetis → String
+  | .centrum  => "center"
+  | .tessella => "tile"
+  | .extende  => "stretch"
+  | .extendeX => "stretch-x"
+  | .extendeY => "stretch-y"
+  | .spatium  => "span"
+
+/-- 選擇モードにゃん。`ingredereModumSelectionis` に渡すにゃ。
+    ukadoc の `\\![enter,selectmode,mode,...]` に對應するにゃん -/
+inductive ModusSelectionis where
+  | rectus  -- rect（矩形選擇にゃ）
+  deriving Repr
+
+def ModusSelectionis.toString : ModusSelectionis → String
+  | .rectus => "rect"
+
+/-- 文字の大きさ指定にゃん。`altitudoLitterarum` に渡すにゃ。
+    ukadoc の `\\f[height,...]` に對應するにゃん。
+    - `absoluta n`   : 絕對ピクセル（例：15）
+    - `relativa n`   : 相對ピクセル（例：+3, -5）
+    - `proportio n`  : 百分率（例：200%）
+    - `praefinita`   : 既定に戾す -/
+inductive MagnitudoLitterarum where
+  | absoluta  (n : Nat)  -- 絕對ピクセルにゃ
+  | relativa  (n : Int)  -- 相對ピクセル（+/-）にゃ
+  | proportio (n : Int)  -- 百分率にゃ
+  | praefinita           -- default にゃ
+  deriving Repr
+
+def MagnitudoLitterarum.toString : MagnitudoLitterarum → String
+  | .absoluta n  => s!"{n}"
+  | .relativa n  => if n ≥ 0 then s!"+{n}" else s!"{n}"
+  | .proportio n => s!"{n}%"
+  | .praefinita  => "default"
+
 /-- 色の指定方法にゃん。
     - `rgb r g b`  : RGB 各 0〜255（`\f[color,...]` で r,g,b に展開されるにゃ）
     - `hex s`      : 16 進數文字列 "RRGGBB" または "#RRGGBB" にゃ
     - `nomen n`    : "red" "white" など名前付き色にゃ
-    - `nullus`     : "none"（影色を無效化するときに使ふにゃ）-/
+    - `nullus`     : "none"（影色を無效化するときに使ふにゃ）
+    - `praefinitus`                    : "default"（既定色に戾すにゃ）
+    - `inhabilis`                      : "disable"（色指定を無效化するにゃ）
+    - `praefinitusAncorae`             : "default.anchor"
+    - `praefinitusAncoraeNonElectae`   : "default.anchornotselect"
+    - `praefinitusAncoraeVisae`        : "default.anchorvisited"
+    - `praefinitusCursoris`            : "default.cursor"
+    - `praefinitusCursorisNonElecti`   : "default.cursornotselect"
+    - `praefinitusPlanus`              : "default.plain" -/
 inductive Coloris where
   | rgb   (r g b : Nat) (hr : r ≤ 255 := by omega) (hg : g ≤ 255 := by omega) (hb : b ≤ 255 := by omega)
   | hex   (s : String)
   | nomen (n : String)
   | nullus
+  | praefinitus
+  | inhabilis
+  | praefinitusAncorae
+  | praefinitusAncoraeNonElectae
+  | praefinitusAncoraeVisae
+  | praefinitusCursoris
+  | praefinitusCursorisNonElecti
+  | praefinitusPlanus
   deriving Repr
 
 def Coloris.toString : Coloris → String
-  | .rgb r g b .. => s!"{r},{g},{b}"
-  | .hex s        => s
-  | .nomen n      => n
-  | .nullus       => "none"
+  | .rgb r g b ..                  => s!"{r},{g},{b}"
+  | .hex s                         => s
+  | .nomen n                       => n
+  | .nullus                        => "none"
+  | .praefinitus                   => "default"
+  | .inhabilis                     => "disable"
+  | .praefinitusAncorae            => "default.anchor"
+  | .praefinitusAncoraeNonElectae  => "default.anchornotselect"
+  | .praefinitusAncoraeVisae       => "default.anchorvisited"
+  | .praefinitusCursoris           => "default.cursor"
+  | .praefinitusCursorisNonElecti  => "default.cursornotselect"
+  | .praefinitusPlanus             => "default.plain"
 
 /-- 音聲コマンドのオプション群にゃん。
     指定したフィールドだけが出力されるにゃ。
@@ -285,7 +441,7 @@ structure OptionesDialogi where
   filtrum          : Option String             := none
   nomen            : Option String             := none
   extensio         : Option String             := none
-  colorisInitialis : Option (Nat × Nat × Nat) := none
+  colorisInitialis : Option Coloris := none
   deriving Repr
 
 def OptionesDialogi.toString (o : OptionesDialogi) : String :=
@@ -296,7 +452,7 @@ def OptionesDialogi.toString (o : OptionesDialogi) : String :=
   let ps := match o.filtrum          with | none => ps | some s => ps ++ [s!"--filter={s}"]
   let ps := match o.nomen            with | none => ps | some s => ps ++ [s!"--name={s}"]
   let ps := match o.extensio         with | none => ps | some s => ps ++ [s!"--ext={s}"]
-  let ps := match o.colorisInitialis with | none => ps | some (r, g, b) => ps ++ [s!"--color={r} {g} {b}"]
+  let ps := match o.colorisInitialis with | none => ps | some c => ps ++ [s!"--color={c.toString}"]
   ",".intercalate ps
 
 /-- ダイアローグスのタイトルを設定するにゃん -/
@@ -323,9 +479,9 @@ def OptionesDialogi.cumNomine (o : OptionesDialogi) (s : String) : OptionesDialo
 def OptionesDialogi.cumExtensione (o : OptionesDialogi) (s : String) : OptionesDialogi :=
   { o with extensio := some s }
 
-/-- 初期色を RGB で設定するにゃん（色選擇ダイアローグス専用にゃ） -/
-def OptionesDialogi.cumColore (o : OptionesDialogi) (r g b : Nat) : OptionesDialogi :=
-  { o with colorisInitialis := some (r, g, b) }
+/-- 初期色を設定するにゃん（色選擇ダイアローグス専用にゃ） -/
+def OptionesDialogi.cumColore (o : OptionesDialogi) (c : Coloris) : OptionesDialogi :=
+  { o with colorisInitialis := some c }
 
 /-- ゴースト・シェル・吹出し切替コマンドのオプション群にゃん。
     - `excitaEventum` : 切替後に OnShellChanged 等のイベントを發生させる（`--option=raise-event`） -/

--- a/docs/SakuraScriptum.md
+++ b/docs/SakuraScriptum.md
@@ -129,8 +129,12 @@ color (.hex "#FF0000")    -- 16進
 color (.nomen "red")      -- 名前
 
 -- サイズ・フォント
-altitudoLitterarum 14    -- \f[height,14]
-nomenFontis "MS Gothic"  -- \f[name,MS Gothic]
+altitudoLitterarum (.absoluta 14)    -- \f[height,14]
+altitudoLitterarum (.relativa 3)     -- \f[height,+3]
+altitudoLitterarum (.relativa (-5))  -- \f[height,-5]
+altitudoLitterarum (.proportio 200)  -- \f[height,200%]
+altitudoLitterarum .praefinita       -- \f[height,default]
+nomenFontis "MS Gothic"             -- \f[name,MS Gothic]
 
 -- 文字揃え
 allineatio .centrum         -- \f[align,center]
@@ -138,12 +142,17 @@ allineatioVerticalis .summum -- \f[valign,top]
 
 -- 影・輪郭
 colorUmbrae (.rgb 0 0 0)
-stylumUmbrae "drop"
-contornus "white"
+stylumUmbrae .offset        -- \f[shadowstyle,offset]
+stylumUmbrae .contornus     -- \f[shadowstyle,outline]
+contornus .activus          -- \f[outline,true]
+contornus .inhabilis        -- \f[outline,disable]
 ```
 
 `DirectioAllineatio` の値: `.sinistrum` `.dextrum` `.centrum` `.contentum`
 `DirectioVerticalis` の値: `.summum` `.medium` `.imum`
+`StylusUmbrae` の値: `.offset` `.contornus` `.praefinitus`
+`StatusContorni` の値: `.activus` `.inactivus` `.praefinitus` `.inhabilis`
+`MagnitudoLitterarum` の値: `.absoluta n` `.relativa n` `.proportio n` `.praefinita`
 
 ---
 
@@ -230,7 +239,7 @@ claudeDialogum "myDialogId"
 | `cumFiltro s` | `--filter=s` |
 | `cumNomine s` | `--name=s` |
 | `cumExtensione s` | `--ext=s` |
-| `cumColore r g b` | `--color=R G B`（色選択専用） |
+| `cumColore c` | `--color=...`（色選択専用、`Coloris` 型） |
 
 ---
 
@@ -406,7 +415,7 @@ reseraRepictura  -- ロック解除
 configuraStatusFenestrae .semperSupra   -- 最前面固定
 configuraStatusFenestrae .minime        -- 最小化
 allineatioDesktop .imum                 -- 下部吸着
-configuratioScalae 150                  -- 拡大率 150%
+configuratioScalae 150                  -- 拡大率 150%（Int 型、負値で軸反転）
 configuratioAlphae 80                   -- 透明度 80（0〜100、コンパイル時検証）
 configuraPositionem 0 0 0               -- 位置固定
 reseraPositionem                        -- 位置固定解除
@@ -439,7 +448,9 @@ animaAddOverlayFast 3
 ## 着せ替え・効果
 
 ```lean
-nexaDressup "hat" "top" "redhat"   -- \![bind,hat,top,redhat]
+nexaDressup "hat" "top" (some true)  -- \![bind,hat,top,1]（着衣）
+nexaDressup "hat" "top" (some false) -- \![bind,hat,top,0]（脱衣）
+nexaDressup "hat" "top"              -- \![bind,hat,top]（トグル）
 applicaEffectum "blur.dll" 60 ""
 applicaFiltratum "sepia.dll" 500 ""
 applicaFiltratum "" 0 ""           -- フィルター除去
@@ -569,7 +580,9 @@ imagoBullaeInlineata "img.png"
 imagoBullaeInlineataOpaca "img.png"
 lineaProportionalis 50    -- \n[percent,50]（Int 型: 負値・100超も指定可能）
 linearisAbrogatur         -- \_n（自動改行禁止）
-allineatioBullae 1        -- \![set,balloonalign,1]
+allineatioBullae .sinistrum -- \![set,balloonalign,left]
+allineatioBullae .centrum   -- \![set,balloonalign,center]
+allineatioBullae .nullus    -- \![set,balloonalign,none]
 tempusBullae 3000         -- 3秒で消える
 moraTextus 200            -- テキストスクロール速度
 signatumBullae "marker"
@@ -598,7 +611,7 @@ egrediereModumInductivum
 ingredereModumCollisionis          -- \![enter,collisionmode]
 ingredereModumCollisionis true     -- 矩形衝突
 egrediereModumCollisionis
-ingredereModumSelectionis "rect" "0,0,100,100"
+ingredereModumSelectionis .rectus "0,0,100,100"
 egrediereModumSelectionis
 ingredereSticky
 egrediereSticky
@@ -691,7 +704,7 @@ def talkScriptum : SakuraPura Unit := scriptum!
 | `\b[n]` / `\b[-1]` | `bulla n` / `bullaAbsconde` | 吹出し |
 | `\f[bold, b]` | `audax b` | 太字 |
 | `\f[color, c]` | `color c` | 色 |
-| `\f[height, n]` | `altitudoLitterarum n` | 文字サイズ |
+| `\f[height, n]` | `altitudoLitterarum mag` | 文字サイズ（MagnitudoLitterarum 型） |
 | `\f[default]` | `formaPraefinita` | 書式リセット |
 | `\_v["file"]` | `sonus "file"` | 音声 |
 | `\8["file"]` | `sonus8 "file"` | 簡易音声 |
@@ -774,12 +787,12 @@ def talkScriptum : SakuraPura Unit := scriptum!
 | `\![set,balloonmarker, "s"]` | `signatumBullae "s"` | バルーンマーカー |
 | `\![set,blink, b]` | `nictatus b` | まばたき設定 |
 | `\![set,alwaysontop, b]` | `semperSupra b` | 最前面設定 |
-| `\![set,scaling, p]` | `configuratioScalae p` | 拡大率 |
+| `\![set,scaling, p]` | `configuratioScalae p` | 拡大率（Int 型、負値で軸反転） |
 | `\![set,alpha, v]` | `configuratioAlphae v` | 透明度 |
 | `\![set,position, x, y, s]` | `configuraPositionem x y s` | 位置固定 |
 | `\![set,shioridebugmode]` | `configuraShioriDebug` | SHIORIデバッグ |
 | `\![set,choicetimeout, ms]` | `tempusOptionum ms` | 選択肢タイムアウト |
-| `\![enter,selectmode, m, c]` | `ingredereModumSelectionis m c` | 選択モード |
+| `\![enter,selectmode, rect, c]` | `ingredereModumSelectionis .rectus c` | 選択モード |
 | `\![leave,selectmode]` | `egrediereModumSelectionis` | 選択モード解除 |
 | `\![call,ghost, "name"]` | `vocaGhost "name"` | ゴースト呼出し |
 | `\![update,platform]` | `renovaPlatformam` | プラットフォーム更新 |


### PR DESCRIPTION
String/無制約Nat を使っていた13箇所を ukadoc 仕様に照合し、
適切な列挙型・制約付き型に置き換えることで、不正な入力を
コンパイル時にエラーにする。

主な変更:
- allineatioBullae: Nat → DirectioAllineatioBullae (列挙型)
- configuratioScalae/configuraScalamDualem: Nat → Int (負値で軸反転)
- altitudoLitterarum: Nat → MagnitudoLitterarum (絶対/相対/百分率/default)
- OptionesDialogi.colorisInitialis: Option (Nat×Nat×Nat) → Option Coloris
- stylumUmbrae: String → StylusUmbrae (offset/outline/default)
- contornus: String → StatusContorni (true/false/default/disable)
- configuraTapete: String → Option ModusTapetis (center/tile/stretch等)
- ingredereModumSelectionis: String → ModusSelectionis (.rectus)
- nexaDressup valor: String → Option Bool (1/0/toggle)
- Coloris に default/disable/default.anchor 等 8 バリアント追加
- MethodusMarci に Win32 SetROP2 全 16 モード追加

https://claude.ai/code/session_01GD1WtVwnZ93jxGjxKbaFBw