### PR TITLE
リテラルキーワードをタグ内にスコープ: インライン方式で衝突回避

### DIFF
--- a/Signaculum/Notatio/Fenestra.lean
+++ b/Signaculum/Notatio/Fenestra.lean
@@ -100,8 +100,28 @@ macro_rules | `(expandSignum \![set,windowstate, $s]) => `(Signaculum.Sakura.con
 syntax "\\!" "[set,alignmentondesktop," term "]" : sakuraSignum
 macro_rules | `(expandSignum \![set,alignmentondesktop, $d]) => `(Signaculum.Sakura.allineatioDesktop $d)
 
-syntax "\\!" "[set,balloonalign," term "]" : sakuraSignum
-macro_rules | `(expandSignum \![set,balloonalign, $d]) => `(Signaculum.Sakura.allineatioBullae $d)
+-- バルーン整列インラインリテラルにゃん♪ タグの中だけでキーワードが有效にゃ
+syntax "\\!" "[set,balloonalign," "left" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, left]) => `(Signaculum.Sakura.allineatioBullae .sinistrum)
+
+syntax "\\!" "[set,balloonalign," "center" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, center]) => `(Signaculum.Sakura.allineatioBullae .centrum)
+
+syntax "\\!" "[set,balloonalign," "top" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, top]) => `(Signaculum.Sakura.allineatioBullae .summum)
+
+syntax "\\!" "[set,balloonalign," "right" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, right]) => `(Signaculum.Sakura.allineatioBullae .dextrum)
+
+syntax "\\!" "[set,balloonalign," "bottom" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, bottom]) => `(Signaculum.Sakura.allineatioBullae .imum)
+
+syntax "\\!" "[set,balloonalign," "none" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, none]) => `(Signaculum.Sakura.allineatioBullae .nullus)
+
+-- 後方互換: 括弧で包めば任意の Lean 式を渡せるにゃ
+syntax "\\!" "[set,balloonalign," "(" term ")" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,balloonalign, ($d)]) => `(Signaculum.Sakura.allineatioBullae $d)
 
 syntax "\\!" "[set,balloontimeout," term "]" : sakuraSignum
 macro_rules | `(expandSignum \![set,balloontimeout, $n]) => `(Signaculum.Sakura.tempusBullae $n)

--- a/Signaculum/Notatio/Fons.lean
+++ b/Signaculum/Notatio/Fons.lean
@@ -11,24 +11,48 @@ open Lean Signaculum.Sakura
 
 syntax "\\f" "[" fontisClavis "]" : sakuraSignum
 
--- Bool 系にゃん
-syntax "bold" "," term : fontisClavis
-macro_rules | `(expandSignum \f[bold, $b]) => `(Signaculum.Sakura.audax $b)
+-- Bool 系インラインリテラルにゃん♪ true/false をそのまま書けるにゃ
+syntax "bold" "," "true" : fontisClavis
+macro_rules | `(expandSignum \f[bold, true]) => `(Signaculum.Sakura.audax Bool.true)
+syntax "bold" "," "false" : fontisClavis
+macro_rules | `(expandSignum \f[bold, false]) => `(Signaculum.Sakura.audax Bool.false)
+syntax "bold" "," "(" term ")" : fontisClavis
+macro_rules | `(expandSignum \f[bold, ($b)]) => `(Signaculum.Sakura.audax $b)
 
-syntax "italic" "," term : fontisClavis
-macro_rules | `(expandSignum \f[italic, $b]) => `(Signaculum.Sakura.obliquus $b)
+syntax "italic" "," "true" : fontisClavis
+macro_rules | `(expandSignum \f[italic, true]) => `(Signaculum.Sakura.obliquus Bool.true)
+syntax "italic" "," "false" : fontisClavis
+macro_rules | `(expandSignum \f[italic, false]) => `(Signaculum.Sakura.obliquus Bool.false)
+syntax "italic" "," "(" term ")" : fontisClavis
+macro_rules | `(expandSignum \f[italic, ($b)]) => `(Signaculum.Sakura.obliquus $b)
 
-syntax "underline" "," term : fontisClavis
-macro_rules | `(expandSignum \f[underline, $b]) => `(Signaculum.Sakura.sublinea $b)
+syntax "underline" "," "true" : fontisClavis
+macro_rules | `(expandSignum \f[underline, true]) => `(Signaculum.Sakura.sublinea Bool.true)
+syntax "underline" "," "false" : fontisClavis
+macro_rules | `(expandSignum \f[underline, false]) => `(Signaculum.Sakura.sublinea Bool.false)
+syntax "underline" "," "(" term ")" : fontisClavis
+macro_rules | `(expandSignum \f[underline, ($b)]) => `(Signaculum.Sakura.sublinea $b)
 
-syntax "strike" "," term : fontisClavis
-macro_rules | `(expandSignum \f[strike, $b]) => `(Signaculum.Sakura.deletura $b)
+syntax "strike" "," "true" : fontisClavis
+macro_rules | `(expandSignum \f[strike, true]) => `(Signaculum.Sakura.deletura Bool.true)
+syntax "strike" "," "false" : fontisClavis
+macro_rules | `(expandSignum \f[strike, false]) => `(Signaculum.Sakura.deletura Bool.false)
+syntax "strike" "," "(" term ")" : fontisClavis
+macro_rules | `(expandSignum \f[strike, ($b)]) => `(Signaculum.Sakura.deletura $b)
 
-syntax "sub" "," term : fontisClavis
-macro_rules | `(expandSignum \f[sub, $b]) => `(Signaculum.Sakura.subscriptus $b)
+syntax "sub" "," "true" : fontisClavis
+macro_rules | `(expandSignum \f[sub, true]) => `(Signaculum.Sakura.subscriptus Bool.true)
+syntax "sub" "," "false" : fontisClavis
+macro_rules | `(expandSignum \f[sub, false]) => `(Signaculum.Sakura.subscriptus Bool.false)
+syntax "sub" "," "(" term ")" : fontisClavis
+macro_rules | `(expandSignum \f[sub, ($b)]) => `(Signaculum.Sakura.subscriptus $b)
 
-syntax "sup" "," term : fontisClavis
-macro_rules | `(expandSignum \f[sup, $b]) => `(Signaculum.Sakura.superscriptus $b)
+syntax "sup" "," "true" : fontisClavis
+macro_rules | `(expandSignum \f[sup, true]) => `(Signaculum.Sakura.superscriptus Bool.true)
+syntax "sup" "," "false" : fontisClavis
+macro_rules | `(expandSignum \f[sup, false]) => `(Signaculum.Sakura.superscriptus Bool.false)
+syntax "sup" "," "(" term ")" : fontisClavis
+macro_rules | `(expandSignum \f[sup, ($b)]) => `(Signaculum.Sakura.superscriptus $b)
 
 -- 色系にゃん（colorisLiteral で SakuraScript リテラルが直接書けるにゃ）
 syntax "color" "," colorisLiteral : fontisClavis

--- a/Signaculum/Notatio/Systema.lean
+++ b/Signaculum/Notatio/Systema.lean
@@ -186,6 +186,7 @@ syntax "\\!" "[load,makoto]" : sakuraSignum
 macro_rules | `(expandSignum \![load,makoto]) => `(Signaculum.Sakura.oneraMakoto)
 
 -- 着替・效果にゃん
+-- 着替にゃん♪ 0/1 のみ受け付けるにゃ（それ以外はマクロエラーにゃ）
 syntax "\\!" "[bind," str "," str "," num "]" : sakuraSignum
 macro_rules
   | `(expandSignum \![bind, $c, $p, $v:num]) =>
@@ -403,8 +404,28 @@ macro_rules | `(expandSignum \![set,othersurfacechange, $b]) => `(Signaculum.Sak
 syntax "\\!" "[set,wallpaper," str "]" : sakuraSignum
 macro_rules | `(expandSignum \![set,wallpaper, $v]) => `(Signaculum.Sakura.configuraTapete $v Option.none)
 
-syntax "\\!" "[set,wallpaper," str "," term "]" : sakuraSignum
-macro_rules | `(expandSignum \![set,wallpaper, $v, $m]) => `(Signaculum.Sakura.configuraTapete $v (Option.some $m))
+-- 壁紙モードインラインリテラルにゃん♪ タグの中だけでキーワードが有效にゃ
+syntax "\\!" "[set,wallpaper," str "," "center" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, center]) => `(Signaculum.Sakura.configuraTapete $v (Option.some .centrum))
+
+syntax "\\!" "[set,wallpaper," str "," "tile" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, tile]) => `(Signaculum.Sakura.configuraTapete $v (Option.some .tessella))
+
+syntax "\\!" "[set,wallpaper," str "," "stretch" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, stretch]) => `(Signaculum.Sakura.configuraTapete $v (Option.some .extende))
+
+syntax "\\!" "[set,wallpaper," str "," "stretch-x" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, stretch-x]) => `(Signaculum.Sakura.configuraTapete $v (Option.some .extendeX))
+
+syntax "\\!" "[set,wallpaper," str "," "stretch-y" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, stretch-y]) => `(Signaculum.Sakura.configuraTapete $v (Option.some .extendeY))
+
+syntax "\\!" "[set,wallpaper," str "," "span" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, span]) => `(Signaculum.Sakura.configuraTapete $v (Option.some .spatium))
+
+-- 後方互換: 括弧で包めば任意の Lean 式を渡せるにゃ
+syntax "\\!" "[set,wallpaper," str "," "(" term ")" "]" : sakuraSignum
+macro_rules | `(expandSignum \![set,wallpaper, $v, ($m)]) => `(Signaculum.Sakura.configuraTapete $v (Option.some $m))
 
 syntax "\\!" "[set,shioridebugmode]" : sakuraSignum
 macro_rules | `(expandSignum \![set,shioridebugmode]) => `(Signaculum.Sakura.configuraShioriDebug)

--- a/Signaculum/Notatio/Verificatio.lean
+++ b/Signaculum/Notatio/Verificatio.lean
@@ -37,7 +37,11 @@ example : Id.run (currereScriptum (scriptum! \b[0])) = "\\b[0]" := by native_dec
 example : Id.run (currereScriptum (scriptum! \b[-1])) = "\\b[-1]" := by native_decide
 
 -- 書體の検證にゃん
-example : Id.run (currereScriptum (scriptum! \f[bold, Bool.true])) = "\\f[bold,true]" := by native_decide
+example : Id.run (currereScriptum (scriptum! \f[bold, true])) = "\\f[bold,true]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[bold, false])) = "\\f[bold,false]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \f[italic, true])) = "\\f[italic,true]" := by native_decide
 
 example : Id.run (currereScriptum (scriptum! \f[default])) = "\\f[default]" := by native_decide
 
@@ -277,14 +281,63 @@ example : Id.run (currereScriptum (scriptum! \f[height, default]))
 --  directioAllineatioBullaeLiteral の検證にゃん
 -- ════════════════════════════════════════════════════
 
-example : Id.run (currereScriptum (scriptum! \![set,balloonalign, .sinistrum]))
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, left]))
         = "\\![set,balloonalign,left]" := by native_decide
 
-example : Id.run (currereScriptum (scriptum! \![set,balloonalign, .centrum]))
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, center]))
         = "\\![set,balloonalign,center]" := by native_decide
 
-example : Id.run (currereScriptum (scriptum! \![set,balloonalign, .nullus]))
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, none]))
         = "\\![set,balloonalign,none]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, top]))
+        = "\\![set,balloonalign,top]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, right]))
+        = "\\![set,balloonalign,right]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, bottom]))
+        = "\\![set,balloonalign,bottom]" := by native_decide
+
+-- 後方互換: 括弧で包む形式にゃん
+example : Id.run (currereScriptum (scriptum! \![set,balloonalign, (.sinistrum)]))
+        = "\\![set,balloonalign,left]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  modusTapetisLiteral の検證にゃん（壁紙モード）
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", center]))
+        = "\\![set,wallpaper,bg.png,center]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", tile]))
+        = "\\![set,wallpaper,bg.png,tile]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", stretch]))
+        = "\\![set,wallpaper,bg.png,stretch]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", stretch-x]))
+        = "\\![set,wallpaper,bg.png,stretch-x]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", stretch-y]))
+        = "\\![set,wallpaper,bg.png,stretch-y]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", span]))
+        = "\\![set,wallpaper,bg.png,span]" := by native_decide
+
+-- 後方互換: 括弧で包む形式にゃん
+example : Id.run (currereScriptum (scriptum! \![set,wallpaper, "bg.png", (.centrum)]))
+        = "\\![set,wallpaper,bg.png,center]" := by native_decide
+
+-- ════════════════════════════════════════════════════
+--  bind インラインの検證にゃん
+-- ════════════════════════════════════════════════════
+
+example : Id.run (currereScriptum (scriptum! \![bind, "category", "part", 1]))
+        = "\\![bind,category,part,1]" := by native_decide
+
+example : Id.run (currereScriptum (scriptum! \![bind, "category", "part", 0]))
+        = "\\![bind,category,part,0]" := by native_decide
 
 -- ════════════════════════════════════════════════════
 --  selectmode の検證にゃん


### PR DESCRIPTION
balloonalign (left/center/top/right/bottom/none)、wallpaper モード
(center/tile/stretch/stretch-x/stretch-y/span)、Bool タグ (bold/italic
等の true/false) のキーワードを各タグの syntax ルールに直接埋め込み、
Literalia の import なしで自然な記法を実現。後方互換の ("(" term ")")
フォールバックも全タグに追加。Verificatio に全キーワードの出力検證を追加。

https://claude.ai/code/session_01PjmTWns5qqLr96GTWyvMEf