### PR TITLE
ビルドエラー修正: TestGhost に main 追加 + Lemma.lean の未使用 simp 引数削除

### DIFF
--- a/Signaculum/Memoria/Lemma.lean
+++ b/Signaculum/Memoria/Lemma.lean
@@ -148,7 +148,7 @@ instance {α : Type} [StatusPermanens α] : StatusPermanens (Option α) where
         have hsize : (.mk #[1] ++ StatusPermanens.adBytes v).size ≠ 0 := by
           rw [ByteArray.size_append, show (ByteArray.mk #[1]).size = 1 from rfl]
           omega
-        simp only [hsize, dif_neg hsize, ite_false]
+        simp only [hsize]
         have h0 : (.mk #[1] ++ StatusPermanens.adBytes v)[0]'(by omega) = 1 := by rfl
         have hne : (1 : UInt8) ≠ 0 := by decide
         simp only [h0, hne, ite_false]

--- a/TestGhost.lean
+++ b/TestGhost.lean
@@ -71,3 +71,13 @@ def testPuraSakura : String := Id.run do
     loqui "テスト完了にゃ。"
     finis
 
+-- ═══════════════════════════════════════════════════
+-- エントリーポイントにゃん
+-- ═══════════════════════════════════════════════════
+
+def main : IO Unit := do
+  IO.println "=== TestGhost ==="
+  IO.println s!"SakuraScript 生成テスト:\n{testPuraSakura}"
+  let registrata ← Signaculum.estRegistrata
+  IO.println s!"栞登錄狀態: {registrata}"
+


### PR DESCRIPTION
- TestGhost.lean: main 関数がなくリンカエラー (undefined symbol: main) が
  発生していたため、テスト結果を出力する main を追加
- Memoria/Lemma.lean: simp only から未使用の dif_neg hsize, ite_false を削除

https://claude.ai/code/session_01A1BqAdZXTwYRzPWTNmKcjb