### PR TITLE
Allow single quotes in bare text without tag termination

### DIFF
--- a/Signaculum/Notatio/Macro.lean
+++ b/Signaculum/Notatio/Macro.lean
@@ -159,7 +159,7 @@ def withInitioLineae : Lean.Parser.Parser → Lean.Parser.Parser :=
 -- SakuraScript タグ開始文字にゃ（これらに遭遇したら停止して categoryParser に委ねるにゃん）
 -- \ → タグ接頭辭、" → 文字列リテラル、{ } → 式埋込、% → 環境變數、) ] → 括弧閉ぢ
 private def estInitiumTagi (ch : Char) : Bool :=
-  ch == '\\' || ch == '"' || ch == '\'' || ch == '{' || ch == '}' || ch == '%' ||
+  ch == '\\' || ch == '"' || ch == '{' || ch == '}' || ch == '%' ||
   ch == ')' || ch == ']'
 
 -- scriptum ブロック內の裸テクストゥスを讀むにゃん♪

--- a/Signaculum/Notatio/Verificatio.lean
+++ b/Signaculum/Notatio/Verificatio.lean
@@ -373,4 +373,12 @@ example : Id.run (currereScriptum (scriptum! \f[cursormethod, copypen]))
 example : Id.run (currereScriptum (scriptum! \f[cursormethod, notmaskpen]))
         = "\\f[cursormethod,notmaskpen]" := by native_decide
 
+-- ════════════════════════════════════════════════════
+--  シングルクォートの検證にゃん
+-- ════════════════════════════════════════════════════
+
+-- シングルクォートを含む裸テクストゥスが分斷されずに讀めるにゃん
+example : Id.run (currereScriptum (scriptum! \h it's \e))
+        = "\\hit's\\e" := by native_decide
+
 end Signaculum.Notatio.Verificatio


### PR DESCRIPTION
## Summary
This change allows single quotes (`'`) to appear in bare text within scriptum blocks without being treated as tag delimiters. Previously, single quotes were incorrectly classified as tag initiation characters, causing text like `it's` to be improperly parsed.

## Key Changes
- **Macro.lean**: Removed single quote (`'`) from the `estInitiumTagi` predicate that identifies tag start characters. Single quotes are no longer treated as special delimiters in bare text parsing.
- **Verificatio.lean**: Added a test case verifying that bare text containing single quotes (e.g., `\h it's \e`) is correctly parsed as a single continuous string without unwanted segmentation.

## Implementation Details
The fix simplifies the tag initiation check by removing the condition `ch == '\''` from the character classification logic. This allows apostrophes and other single quote characters to be treated as regular text characters within bare text contexts, matching the expected behavior for natural language text.

https://claude.ai/code/session_01MuoQ6PLB6AfZMMXzCBNFYy