### PR TITLE
Refactor scriptum elaboration with per-tag hover info support

### DIFF
--- a/Signaculum/Notatio/Macro.lean
+++ b/Signaculum/Notatio/Macro.lean
@@ -256,7 +256,7 @@ end Signaculum.Notatio
 --  scriptum! パーサー + エラボレーター (ネームスペース外で宣言にゃん)
 -- ════════════════════════════════════════════════════
 
-open Lean Elab Term Signaculum.Notatio
+open Lean Elab Term Meta Signaculum.Notatio
 
 /-- SakuraScript を原形タグ記法で書けるパーサにゃん。
     行の先頭列より深いトークンだけ取り込むにゃ♪
@@ -277,11 +277,19 @@ private def scriptumParserCore (kw : String) : Lean.Parser.Parser :=
 -- stx[1] が sakuraSignum* の null ノードにゃ
 -- rawTextusFn が積んだ生 ident ノード（isIdent = true）は直接 loqui に変換にゃ
 -- sakuraSignum ラッパーを持つ正規ノードは expandSignum 経由にゃ
+-- 各タグを個別にエラボレートしてホバー情報を登録するにゃん♪
+
+/-- 二つの SakuraM アクションを順次結合する Expr を作るにゃん。
+    Bind.bind a (fun () => b) に相當するにゃ -/
+private def mkSequentia (a b : Expr) : TermElabM Expr := do
+  let lam := Expr.lam `_ (mkConst ``Unit) b .default
+  mkAppM ``Bind.bind #[a, lam]
+
 @[term_elab scriptumMacro]
 def elabScriptum : TermElab := fun stx expectedType? => do
   let ss := stx[1].getArgs
-  -- 各シグナムノードを term に變換するにゃ
-  let genTerm (s : Lean.Syntax) : Lean.Elab.Term.TermElabM (TSyntax `term) := do
+  -- 各シグナムノードを term 構文に變換するにゃ
+  let genTermStx (s : Lean.Syntax) : Lean.Elab.Term.TermElabM (TSyntax `term) := do
     if s.isIdent then
       -- rawTextusFn 由來の裸 ident にゃ → rawVal から直接文字列を取るにゃん（guillemet 回避）
       let textus := match s with
@@ -291,6 +299,13 @@ def elabScriptum : TermElab := fun stx expectedType? => do
     else
       let ts : TSyntax `sakuraSignum := ⟨s⟩
       `(expandSignum $ts)
+  -- 單一シグナムをエラボレートしてホバー情報を登録するにゃん
+  -- withRef で元のタグ構文の位置を參照點にし、addTermInfo でホバーを紐づけるにゃ
+  let elabUnum (s : Lean.Syntax) : TermElabM Expr := do
+    let termStx ← genTermStx s
+    let expr ← withRef s <| elabTerm termStx none
+    addTermInfo s expr
+    return expr
   if h : 0 < ss.size then
     -- フォンティスのタブラから行番號を得るにゃん♪
     -- 異なる行のシグナム間に自動で linea（\n）を挿入するにゃ
@@ -301,7 +316,7 @@ def elabScriptum : TermElab := fun stx expectedType? => do
         | .synthetic (pos := p) .. => some p
         | .none => Option.none
       pos?.map fun pos => (tabulaFontis.toPosition pos).line
-    let mut body ← genTerm (ss[0]'h)
+    let mut result ← elabUnum (ss[0]'h)
     let mut lineaPrior := lineamSigni (ss[0]'h)
     for s in ss[1:] do
       -- 前のシグナムと行が違ったら \n を挾むにゃ
@@ -309,11 +324,14 @@ def elabScriptum : TermElab := fun stx expectedType? => do
       match lineaPrior, lineaCurrens with
       | some lp, some lc =>
         if lc > lp then
-          body ← `(Bind.bind $body fun () => Signaculum.Sakura.linea)
+          let lineaExpr ← elabTerm (← `(Signaculum.Sakura.linea)) none
+          result ← mkSequentia result lineaExpr
       | _, _ => pure ()
-      let next ← genTerm s
-      body ← `(Bind.bind $body fun () => $next)
+      let nextExpr ← elabUnum s
+      result ← mkSequentia result nextExpr
       lineaPrior := lineaCurrens
-    elabTerm body expectedType?
+    match expectedType? with
+    | some t => ensureHasType t result
+    | none   => return result
   else
     elabTerm (← `(pure ())) expectedType?


### PR DESCRIPTION
## Summary
Refactored the `elabScriptum` macro elaborator to properly register hover information for individual SakuraScript tags and improve expression sequencing.

## Key Changes

- **Added `Meta` namespace import**: Required for proper term elaboration and hover info registration
- **Introduced `mkSequentia` helper**: New function to create sequenced `Bind.bind` expressions for combining SakuraM actions, replacing inline quasi-quotation syntax
- **Renamed `genTerm` to `genTermStx`**: Clarifies that this function generates term syntax, not elaborated expressions
- **Added `elabUnum` function**: New elaboration function that:
  - Elaborates individual SakuraScript tags to expressions
  - Uses `withRef` to associate elaboration with original tag syntax position
  - Registers hover information via `addTermInfo` for each tag
- **Refactored main elaboration loop**:
  - Changed from building syntax (`body`) to building expressions (`result`)
  - Uses `elabUnum` for per-tag elaboration instead of deferred elaboration
  - Replaced inline quasi-quotation for `Bind.bind` calls with `mkSequentia`
  - Improved type handling with explicit `ensureHasType` call when expected type is provided

## Implementation Details

The key improvement is moving from a two-phase approach (syntax generation → single elaboration) to a per-tag elaboration approach. This enables proper hover information registration for each individual tag while maintaining correct expression sequencing through the new `mkSequentia` helper function.

https://claude.ai/code/session_01Uxe25cys39jnjPu2VqgumF