### PR TITLE
scriptum タグのホバーにタグ種別情報を表示

### DIFF
--- a/Signaculum/Notatio/Macro.lean
+++ b/Signaculum/Notatio/Macro.lean
@@ -305,7 +305,6 @@ def elabScriptum : TermElab := fun stx expectedType? => do
     let termStx ← genTermStx s
     let expr ← withRef s <| elabTerm termStx none
     addTermInfo s expr
-    return expr
   if h : 0 < ss.size then
     -- フォンティスのタブラから行番號を得るにゃん♪
     -- 異なる行のシグナム間に自動で linea（\n）を挿入するにゃ
@@ -330,8 +329,6 @@ def elabScriptum : TermElab := fun stx expectedType? => do
       let nextExpr ← elabUnum s
       result ← mkSequentia result nextExpr
       lineaPrior := lineaCurrens
-    match expectedType? with
-    | some t => ensureHasType t result
-    | none   => return result
+    ensureHasType expectedType? result
   else
     elabTerm (← `(pure ())) expectedType?


### PR DESCRIPTION
## Summary

- `scriptum` ブロック内のタグ（`\h`, `\s[0]`, `\e` 等）をホバーした際、型（`SakuraIO Unit`）だけでなく対応する関数の docstring（タグの説明）も表示されるよう、エラボレーターを改修
- 各タグを個別に `elabTerm` + `addTermInfo` でエラボレートし、`Bind.bind` チェーンを `Expr` レベルで構築する方式に変更

## Test plan

- [x] `lake build` 成功を確認
- [ ] VS Code + Lean 拡張で `scriptum` ブロック内のタグをホバーし、docstring が表示されることを確認

https://claude.ai/code/session_01Uxe25cys39jnjPu2VqgumF